### PR TITLE
Twitter share icon v1

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Layout, PageHeader } from 'antd';
 import styles from './styles.module.css';
+import { Icon } from 'antd';
 
 const { Header: HeaderAntd } = Layout;
 
@@ -8,6 +9,18 @@ const Header = () => {
   return (
     <HeaderAntd className={styles.header}>
       <PageHeader title="JS Intl Kitchen Sink" subTitle="Home" />
+      <a href="https://twitter.com/xgeeksio" className={styles.twitterFollow}>
+        <Icon
+          type="twitter"
+          href="https://twitter.com/xgeeksio"
+          style={{
+            padding: '10px',
+            fontSize: '1.5rem',
+            color: '#fff',
+            cursor: 'pointer',
+          }}
+        />
+      </a>
     </HeaderAntd>
   );
 };

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -16,14 +16,9 @@ const Header = () => {
         className={styles.twitterFollow}
       >
         <Icon
+          className={styles.icon}
           type="twitter"
           href="https://twitter.com/xgeeksio"
-          style={{
-            padding: '10px',
-            fontSize: '1.5rem',
-            color: '#fff',
-            cursor: 'pointer',
-          }}
         />
       </a>
     </HeaderAntd>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -9,7 +9,12 @@ const Header = () => {
   return (
     <HeaderAntd className={styles.header}>
       <PageHeader title="JS Intl Kitchen Sink" subTitle="Home" />
-      <a href="https://twitter.com/xgeeksio" className={styles.twitterFollow}>
+      <a
+        href="https://twitter.com/xgeeksio"
+        rel="noopener noreferrer"
+        target="_black"
+        className={styles.twitterFollow}
+      >
         <Icon
           type="twitter"
           href="https://twitter.com/xgeeksio"

--- a/src/components/Header/styles.module.css
+++ b/src/components/Header/styles.module.css
@@ -2,4 +2,12 @@
   background-color: #f0f2f5;
   text-align: center;
   padding: 0;
+  display: flex;
+  align-items: center;
+}
+
+.twitterFollow {
+  margin: 0 7rem 0 auto;
+  height: 50px;
+  background-color: #563e7c;
 }

--- a/src/components/Header/styles.module.css
+++ b/src/components/Header/styles.module.css
@@ -9,5 +9,17 @@
 .twitterFollow {
   margin: 0 7rem 0 auto;
   height: 50px;
-  background-color: #563e7c;
+}
+
+.icon {
+  padding: 10px;
+  font-size: 1.5rem;
+  color: #5e5e5e;
+  cursor: pointer;
+}
+
+.icon svg:hover {
+  transform: scale(1.1);
+  color: #00acee;
+  transition: all 0.4s ease-in-out;
 }


### PR DESCRIPTION
<!--
#19
-->

## Screenshots (if visual changes)
![Twitter share Icon Top](https://user-images.githubusercontent.com/23227030/66776617-725a8580-eee4-11e9-9d29-36bfafd00be3.png)

The twitter site will open in a new tab, to ensure not lose the user engagement with our site.
Followed best practice, https://developers.google.com/web/tools/lighthouse/audits/noopener

I kept the design as per issue screenshot provided, please let me know if any adjustment to be done.