### PR TITLE
Added Links to Home and DateTimeFormat Pages

### DIFF
--- a/src/pages/DateTimeFormat/data/usefulLinks.js
+++ b/src/pages/DateTimeFormat/data/usefulLinks.js
@@ -22,6 +22,12 @@ const links = [
     avatar: 'https://www.javascripture.com/favicon.ico',
     link: 'https://www.javascripture.com/DateTimeFormat',
   },
+  {
+    title: 'ECMA-402, 6th edition, June 2019',
+    text: 'DateTimeFormat Objects',
+    avatar: 'https://ecma-international.org/ecma-402/img/ecma-logo.svg',
+    link: 'https://ecma-international.org/ecma-402/#datetimeformat-objects',
+  },
 ];
 
 export default links;

--- a/src/pages/Home/data/usefulLinks.js
+++ b/src/pages/Home/data/usefulLinks.js
@@ -9,11 +9,25 @@ const links = [
       'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl',
   },
   {
+    title: 'ECMA-402, 6th edition, June 2019',
+    text: 'ECMAScript® 2019 Internationalization API Specification',
+    avatar: 'https://ecma-international.org/ecma-402/img/ecma-logo.svg',
+    link: 'https://ecma-international.org/ecma-402/',
+  },
+  {
     title: 'Norbert’s Corner',
     text: 'The ECMAScript Internationalization API',
     avatar: 'https://norbertlindenberg.com/favicon.ico',
     link:
       'https://norbertlindenberg.com/2012/12/ecmascript-internationalization-api/index.html',
+  },
+  {
+    title: 'Mozilla Hacks',
+    text: 'Introducing the JavaScript Internationalization API',
+    avatar:
+      'https://2r4s9p1yi1fa2jd7j43zph8r-wpengine.netdna-ssl.com/wp-content/themes/Hax/img/mdn-logo.svg',
+    link:
+      'https://hacks.mozilla.org/2014/12/introducing-the-javascript-internationalization-api/',
   },
 ];
 


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #8 
Fixes #8 

## Screenshots (if visual changes)
Home page:
![Home](https://user-images.githubusercontent.com/9960158/66859775-8f0cc100-efa9-11e9-9d2c-2f8a16c6f5ef.png)
DateTimeFormat Page:
![DateTimeFormat](https://user-images.githubusercontent.com/9960158/66859820-9fbd3700-efa9-11e9-8532-3992157b7348.png)

## Proposed Changes

  - Added two links on home page
  - Added one link on DateTimeFormat page
  
<!--
Mention people who discussed this issue previously
@someone
-->
