### PR TITLE
#33 added search on select for dropdowns with more than 6 options

### DIFF
--- a/src/pages/DateTimeFormat/index.js
+++ b/src/pages/DateTimeFormat/index.js
@@ -247,6 +247,7 @@ const Home = () => {
                   <Col span={12}>
                     <Form.Item label="locale">
                       <Select
+                        showSearch
                         placeholder="Select a locale"
                         onChange={handleLocaleChange}
                       >
@@ -264,6 +265,7 @@ const Home = () => {
                     </Form.Item>
                     <Form.Item label="nu">
                       <Select
+                        showSearch
                         placeholder="Select a Numbering system"
                         onChange={handleOptionsLocaleChange}
                         disabled={disabledBool}
@@ -287,6 +289,7 @@ const Home = () => {
                         onChange={handleOptionsLocaleChange}
                         disabled={disabledBool}
                         value={caString}
+                        showSearch
                       >
                         <Option key="clear" value={undefined}>
                           undefined (clear)


### PR DESCRIPTION
<!--
#33 
-->

Relates to #33 
Fixes #

## Screenshots (if visual changes)
<img width="399" alt="Screen Shot 2019-10-15 at 11 48 30 PM" src="https://user-images.githubusercontent.com/16340801/66895003-a5fde400-efa6-11e9-9788-0be310857e77.png">
## Proposed Changes
Added `showSearch` prop on the `<Select />` components with more than 6 options. The filtering is done on the input by default
  -
  -
  -
  
<!--
Mention people who discussed this issue previously
@luisFilipePT 
-->
