### PR TITLE
Initial version of popups

### DIFF
--- a/src/data/explanations.js
+++ b/src/data/explanations.js
@@ -1,0 +1,264 @@
+import React from 'react';
+import { Typography } from 'antd';
+
+const { Paragraph } = Typography;
+
+const docsPrefix = 'https://developer.mozilla.org';
+
+const explanations = {
+  locales: (
+    <Paragraph>
+      A string with a BCP 47 language tag, or an array of such strings. To use
+      the browser's default locale, omit this argument or pass{' '}
+      <code>undefined</code>. Unicode extension are supported (for example "
+      <code>en-US-u-ca-buddhist</code>"). For the general form and
+      interpretation of the <code>locales</code> argument, see the{' '}
+      <a
+        href={`${docsPrefix}/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation`}
+        title="The Intl object is the namespace for the ECMAScript Internationalization API, which provides language sensitive string comparison, number formatting, and date and time formatting. The INTL object provides access to several constructors as well as functionality common to the internationalization constructors and other language sensitive functions."
+      >
+        Intl page
+      </a>
+      . The following Unicode extension keys are allowed:
+    </Paragraph>
+  ),
+  nu: (
+    <Paragraph>
+      Numbering system. Possible values include: "<code>arab</code>", "
+      <code>arabext</code>", "<code>bali</code>", "<code>beng</code>", "
+      <code>deva</code>", "<code>fullwide</code>", "<code>gujr</code>", "
+      <code>guru</code>", "<code>hanidec</code>", "<code>khmr</code>", "
+      <code>knda</code>", "<code>laoo</code>", "<code>latn</code>", "
+      <code>limb</code>", "<code>mlym</code>", "<code>mong</code>", "
+      <code>mymr</code>", "<code>orya</code>", "<code>tamldec</code>", "
+      <code>telu</code>", "<code>thai</code>", "<code>tibt</code>".
+    </Paragraph>
+  ),
+  ca: (
+    <Paragraph>
+      Calendar. Possible values include: "<code>buddhist</code>", "
+      <code>chinese</code>", "<code>coptic</code>", "<code>ethiopia</code>", "
+      <code>ethiopic</code>", "<code>gregory</code>", "<code>hebrew</code>", "
+      <code>indian</code>", "<code>islamic</code>", "<code>iso8601</code>", "
+      <code>japanese</code>", "<code>persian</code>", "<code>roc</code>".
+    </Paragraph>
+  ),
+  hc: (
+    <Paragraph>
+      Hour cycle. Possible values include: "<code>h11</code>", "<code>h12</code>
+      ", "<code>h23</code>", "<code>h24</code>".
+    </Paragraph>
+  ),
+  dateStyle: (
+    <Paragraph>
+      The date formatting style to use when calling <code>format()</code>.
+      Possible values include:
+      <ul>
+        <li>
+          "<code>full</code>"
+        </li>
+        <li>
+          "<code>long</code>"
+        </li>
+        <li>
+          "<code>medium</code>"
+        </li>
+        <li>
+          "<code>short</code>"
+        </li>
+      </ul>
+    </Paragraph>
+  ),
+  timeStyle: (
+    <Paragraph>
+      The time formatting style to use when calling <code>format()</code>.
+      Possible values include:
+      <ul>
+        <li>
+          "<code>full</code>"
+        </li>
+        <li>
+          "<code>long</code>"
+        </li>
+        <li>
+          "<code>medium</code>"
+        </li>
+        <li>
+          "<code>short</code>"
+        </li>
+      </ul>
+    </Paragraph>
+  ),
+  localeMatcher: (
+    <Paragraph>
+      The locale matching algorithm to use. Possible values are "
+      <code>lookup</code>" and "<code>best fit</code>"; the default is "
+      <code>best fit</code>". For information about this option, see the{' '}
+      <a
+        href={`${docsPrefix}/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_negotiation`}
+        title="The Intl object is the namespace for the ECMAScript Internationalization API, which provides language sensitive string comparison, number formatting, and date and time formatting. The INTL object provides access to several constructors as well as functionality common to the internationalization constructors and other language sensitive functions."
+      >
+        Intl page
+      </a>
+      .
+    </Paragraph>
+  ),
+  timeZone: (
+    <Paragraph>
+      The time zone to use. The only value implementations must recognize is "
+      <code>UTC</code>"; the default is the runtime's default time zone.
+      Implementations may also recognize the time zone names of the{' '}
+      <a class="external" href="https://www.iana.org/time-zones" rel="noopener">
+        IANA time zone database
+      </a>
+      , such as "<code>Asia/Shanghai</code>", "<code>Asia/Kolkata</code>", "
+      <code>America/New_York</code>".
+    </Paragraph>
+  ),
+  hour12: (
+    <Paragraph>
+      Whether to use 12-hour time (as opposed to 24-hour time). Possible values
+      are <code>true</code> and <code>false</code>; the default is locale
+      dependent. This option overrides the <code>hc</code> language tag and/or
+      the <code>hourCycle</code> option in case both are present.
+    </Paragraph>
+  ),
+  hourCycle: (
+    <Paragraph>
+      The hour cycle to use. Possible values are "<code>h11</code>", "
+      <code>h12</code>", "<code>h23</code>", or "<code>h24</code>". This option
+      overrides the <code>hc</code> language tag, if both are present, and the{' '}
+      <code>hour12</code> option takes precedence in case both options have been
+      specified. The hour cycle to use. Possible values are "<code>h11</code>",
+      "<code>h12</code>", "<code>h23</code>", or "<code>h24</code>". This option
+      overrides the <code>hc</code> language tag, if both are present, and the{' '}
+      <code>hour12</code> option takes precedence in case both options have been
+      specified.
+    </Paragraph>
+  ),
+  formatMatcher: (
+    <Paragraph>
+      The format matching algorithm to use. Possible values are "
+      <code>basic</code>" and "<code>best fit</code>"; the default is "
+      <code>best fit</code>". See the following paragraphs for information about
+      the use of this property.
+    </Paragraph>
+  ),
+  weekday: (
+    <Paragraph>
+      The representation of the weekday. Possible values are:
+      <ul>
+        <li>
+          "<code>long</code>" (e.g., <code>Thursday</code>)
+        </li>
+        <li>
+          "<code>short</code>" (e.g., <code>Thu</code>)
+        </li>
+        <li>
+          "<code>narrow</code>" (e.g., <code>T</code>). Two weekdays may have
+          the same narrow style for some locales (e.g. <code>Tuesday</code>'s
+          narrow style is also <code>T</code>).
+        </li>
+      </ul>
+    </Paragraph>
+  ),
+  era: (
+    <Paragraph>
+      The representation of the era. Possible values are:
+      <ul>
+        <li>
+          "<code>long</code>" (e.g., <code>Anno Domini</code>)
+        </li>
+        <li>
+          "<code>short</code>" (e.g., <code>AD</code>)
+        </li>
+        <li>
+          "<code>narrow</code>" (e.g., <code>A</code>)
+        </li>
+      </ul>
+    </Paragraph>
+  ),
+  year: (
+    <Paragraph>
+      The representation of the year. Possible values are:
+      <ul>
+        <li>
+          "<code>numeric</code>" (e.g., <code>2012</code>)
+        </li>
+        <li>
+          "<code>2-digit</code>" (e.g., <code>12</code>)
+        </li>
+      </ul>
+    </Paragraph>
+  ),
+  month: (
+    <Paragraph>
+      The representation of the month. Possible values are:
+      <ul>
+        <li>
+          "<code>numeric</code>" (e.g., <code>2</code>)
+        </li>
+        <li>
+          "<code>2-digit</code>" (e.g., <code>02</code>)
+        </li>
+        <li>
+          "<code>long</code>" (e.g., <code>March</code>)
+        </li>
+        <li>
+          "<code>short</code>" (e.g., <code>Mar</code>)
+        </li>
+        <li>
+          "<code>narrow</code>" (e.g., <code>M</code>). Two months may have the
+          same narrow style for some locales (e.g. <code>May</code>'s narrow
+          style is also <code>M</code>).
+        </li>
+      </ul>
+    </Paragraph>
+  ),
+  day: (
+    <Paragraph>
+      The representation of the day. Possible values are:
+      <ul>
+        <li>
+          "<code>numeric</code>" (e.g., <code>1</code>)
+        </li>
+        <li>
+          "<code>2-digit</code>" (e.g., <code>01</code>)
+        </li>
+      </ul>
+    </Paragraph>
+  ),
+  hour: (
+    <Paragraph>
+      The representation of the hour. Possible values are "<code>numeric</code>
+      ", "<code>2-digit</code>".
+    </Paragraph>
+  ),
+  minute: (
+    <Paragraph>
+      The representation of the minute. Possible values are "
+      <code>numeric</code>", "<code>2-digit</code>".
+    </Paragraph>
+  ),
+  second: (
+    <Paragraph>
+      The representation of the second. Possible values are "
+      <code>numeric</code>", "<code>2-digit</code>".
+    </Paragraph>
+  ),
+  timeZoneName: (
+    <Paragraph>
+      The representation of the time zone name. Possible values are:
+      <ul>
+        <li>
+          "<code>long</code>" (e.g., <code>British Summer Time</code>)
+        </li>
+        <li>
+          "<code>short</code>" (e.g., <code>GMT+1</code>)
+        </li>
+      </ul>
+    </Paragraph>
+  ),
+};
+
+export default explanations;

--- a/src/pages/DateTimeFormat/index.js
+++ b/src/pages/DateTimeFormat/index.js
@@ -18,11 +18,13 @@ import {
   Icon,
   Tooltip,
   Affix,
+  Popover,
 } from 'antd';
 
 import links from '../../data/usefulLinks';
 import locales from '../../data/locales';
 import { numberingSystem, calendar, hourCycle } from '../../data/locales';
+import explanations from '../../data/explanations';
 import ShowCodeModal from '../../components/ShowCodeModal';
 
 import {
@@ -344,7 +346,11 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
               <Row gutter={16}>
                 <Card type="inner" title="Locale" extra={<Tag>Optional</Tag>}>
                   <Col span={12}>
-                    <Form.Item label="locale">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.locales}>locale</Popover>
+                      }
+                    >
                       <Select
                         showSearch
                         value={state.locale}
@@ -363,7 +369,9 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         })}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="nu">
+                    <Form.Item
+                      label={<Popover content={explanations.nu}>nu</Popover>}
+                    >
                       <Select
                         showSearch
                         value={nuString}
@@ -383,7 +391,9 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                     </Form.Item>
                   </Col>
                   <Col span={12}>
-                    <Form.Item label="ca">
+                    <Form.Item
+                      label={<Popover content={explanations.ca}>ca</Popover>}
+                    >
                       <Select
                         placeholder="Select a Calendar"
                         onChange={handleOptionsLocaleChange}
@@ -401,7 +411,9 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="hc">
+                    <Form.Item
+                      label={<Popover content={explanations.hc}>hc</Popover>}
+                    >
                       <Select
                         placeholder="Select a Hour Cycle"
                         onChange={handleOptionsLocaleChange}
@@ -425,7 +437,13 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
               <Row gutter={16}>
                 <Card type="inner" title="Options" extra={<Tag>Optional</Tag>}>
                   <Col span={12}>
-                    <Form.Item label="dateStyle">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.dateStyle}>
+                          dateStyle
+                        </Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a dateStyle"
                         onChange={handleDateStyleChange}
@@ -440,7 +458,13 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="localMatcher">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.localeMatcher}>
+                          localeMatcher
+                        </Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a localMatcher"
                         onChange={handleLocalMatcherChange}
@@ -455,7 +479,13 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="hourCycle">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.hourCycle}>
+                          hourCycle
+                        </Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a hourCycle"
                         onChange={handleHourCycleChange}
@@ -470,7 +500,13 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="weekDay">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.weekday}>
+                          weekDay
+                        </Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a weekDay"
                         onChange={handleWeekDayChange}
@@ -485,7 +521,11 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="year">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.year}>year</Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a year"
                         onChange={handleYearChange}
@@ -500,7 +540,9 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="day">
+                    <Form.Item
+                      label={<Popover content={explanations.day}>day</Popover>}
+                    >
                       <Select
                         placeholder="Select a day"
                         onChange={handleDayChange}
@@ -515,7 +557,11 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="minute">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.minute}>minute</Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a minute"
                         onChange={handleMinuteChange}
@@ -530,7 +576,13 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="timeZoneName">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.timeZoneName}>
+                          timeZoneName
+                        </Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a timeZoneName"
                         onChange={handleTimeZoneNameChange}
@@ -547,7 +599,13 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                     </Form.Item>
                   </Col>
                   <Col span={12}>
-                    <Form.Item label="timeStyle">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.timeStyle}>
+                          timeStyle
+                        </Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a timeStyle"
                         onChange={handleTimeStyleChange}
@@ -562,7 +620,13 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="timeZone">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.timeZone}>
+                          timeZone
+                        </Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a timeZone"
                         onChange={handleTimeZoneChange}
@@ -578,7 +642,13 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="formatMatcher">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.formatMatcher}>
+                          formatMatcher
+                        </Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a formatMatcher"
                         onChange={handleFormatMatcherChange}
@@ -593,7 +663,9 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="era">
+                    <Form.Item
+                      label={<Popover content={explanations.era}>era</Popover>}
+                    >
                       <Select
                         placeholder="Select a era"
                         onChange={handleEraChange}
@@ -608,7 +680,11 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="month">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.month}>month</Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a month"
                         onChange={handleMonthChange}
@@ -623,7 +699,11 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="hour">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.hour}>hour</Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a hour"
                         onChange={handleHourChange}
@@ -638,7 +718,11 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="second">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.second}>second</Popover>
+                      }
+                    >
                       <Select
                         placeholder="Select a second"
                         onChange={handleSecondChange}
@@ -653,7 +737,11 @@ const formattedDate = new Intl.DateTimeFormat('${locale}', {
                         ))}
                       </Select>
                     </Form.Item>
-                    <Form.Item label="hour12">
+                    <Form.Item
+                      label={
+                        <Popover content={explanations.hour12}>hour12</Popover>
+                      }
+                    >
                       <Switch onChange={handleHour12Change} />
                     </Form.Item>
                   </Col>


### PR DESCRIPTION
https://github.com/xgeekshq/js-intl-kitchen-sink/issues/6

Relates to popovers on the form elements  of the DateTimeFormat page

## Screenshots (if visual changes)
![crop](https://user-images.githubusercontent.com/6865038/67164828-dc5caa00-f37e-11e9-9aca-ce33613f80f5.png)


## Proposed Changes
A complete extraction off the docs' explanation.

@luisFilipePT 


P.S. A generic component which will apply some styles to the popover text content can be defined (_PopoverContent_). 
Some rule suggestions: (max-width, line-spacing, font-size, list-style-type, ...). You can check the current implementation and add some styling suggestions as well. Also, I copy pasted the texts from the doc which in many cases expose all the available attributes of the `<select />`. Do let me know if you feel they are redundant in the popover.